### PR TITLE
add maven

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "java",
+			"name": "Debug spritz (Launch)",
+			"request": "launch",
+			"cwd": "${workspaceFolder}",
+			"console": "internalConsole",
+			"stopOnEntry": false,
+			"mainClass": "com.github.boyeborg.spritz.Main",
+			"projectName": "spritz",
+			"args": ""
+		},
+		{
+			"type": "java",
+			"name": "Debug (Attach)",
+			"request": "attach",
+			"hostName": "localhost",
+			"port": 0
+		}
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,83 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+		http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.github.boyeborg</groupId>
+	<artifactId>spritz</artifactId>
+	<version>0.1</version>
+	<packaging>jar</packaging>
+
+	<name>Spritz</name>
+	<description>Freature extraction from event based streams.</description>
+	<url>https://github.com/boyeborg/spritz</url>
+
+	<issueManagement>
+		<system>GitHub</system>
+		<url>https://github.com/boyeborg/spritz/issues</url>
+	</issueManagement>
+
+	<scm>
+		<url>https://github.com/boyeborg/spritz</url>
+	</scm>
+
+	<licenses>
+		<license>
+			<name>GNU General Public License version 3 (GNU GPLv3)</name>
+			<url>https://www.gnu.org/licenses/gpl.txt</url>
+		</license>
+	</licenses>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	
+</project>

--- a/src/main/java/com/github/boyeborg/spritz/Main.java
+++ b/src/main/java/com/github/boyeborg/spritz/Main.java
@@ -1,0 +1,8 @@
+package com.github.boyeborg.spritz;
+
+public class Main {
+	
+	public static void main(final String[] args) {
+		System.out.println("Hello, World!");
+	}
+}

--- a/src/test/java/com/github/boyeborg/spritz/MainTest.java
+++ b/src/test/java/com/github/boyeborg/spritz/MainTest.java
@@ -1,0 +1,19 @@
+package com.github.boyeborg.spritz;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public class MainTest extends TestCase {
+    public MainTest(String testName) {
+        super(testName);
+    }
+
+    public static Test suite() {
+        return new TestSuite(MainTest.class);
+    }
+
+    public void testMain() {
+        assertTrue(true);
+    }
+}

--- a/src/test/java/com/github/boyeborg/spritz/MainTest.java
+++ b/src/test/java/com/github/boyeborg/spritz/MainTest.java
@@ -5,15 +5,16 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 public class MainTest extends TestCase {
-    public MainTest(String testName) {
-        super(testName);
-    }
+	
+	public MainTest(String testName) {
+		super(testName);
+	}
 
-    public static Test suite() {
-        return new TestSuite(MainTest.class);
-    }
+	public static Test suite() {
+		return new TestSuite(MainTest.class);
+	}
 
-    public void testMain() {
-        assertTrue(true);
-    }
+	public void testMain() {
+		assertTrue(true);
+	}
 }


### PR DESCRIPTION
This adds maven to the project, and bootstraps the project with a sample structure similar to what the `archetype:generate` plugin would generate. This fixes #1.