### PR TITLE
enforce editor settings with editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+
+[*.{java,xml}]
+indent_style = tab
+tab_width = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ insert_final_newline = true
 [*.{java,xml}]
 indent_style = tab
 tab_width = 2
+
+[*.{.json,yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This adds an editorconfig file that enforces editor settings of tabs/spaces. This fixes #4.