### PR TITLE
code coverage tracking with jacoco and codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ cache:
 branches:
   only: 
     - master
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,26 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.7.9</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	

--- a/src/test/java/com/github/boyeborg/spritz/MainTest.java
+++ b/src/test/java/com/github/boyeborg/spritz/MainTest.java
@@ -15,6 +15,7 @@ public class MainTest extends TestCase {
 	}
 
 	public void testMain() {
+		(new Main()).main(null);
 		assertTrue(true);
 	}
 }


### PR DESCRIPTION
This adds jacoco which generates coverage reports every time the test goal is set in maven. It also configures Travis to send the coverage report to codecov. This way we can track the code coverage of the project. This fixes #8.