### PR TITLE
turn off travis email notifiactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ branches:
     - master
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+notifications:
+  email: false


### PR DESCRIPTION
This turns off the automatic email notification after every build in Travis. This fixes #9.