### PR TITLE
badges in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Spritz
 
+[![Build Status](https://img.shields.io/travis/boyeborg/spritz/master.svg?style=flat-square)](https://travis-ci.org/boyeborg/spritz)
+
 Freature extraction from event based streams.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 [![Build Status](https://img.shields.io/travis/boyeborg/spritz/master.svg?style=flat-square)](https://travis-ci.org/boyeborg/spritz)
 [![Codecov](https://img.shields.io/codecov/c/github/boyeborg/spritz/master.svg?style=flat-square)](https://codecov.io/gh/boyeborg/spritz)
+[![JitPack](https://img.shields.io/jitpack/v/boyeborg/spritz.svg?style=flat-square)](https://jitpack.io/#boyeborg/spritz)
 
 Freature extraction from event based streams.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spritz
 
-[![Build Status](https://img.shields.io/travis/boyeborg/spritz/master.svg?style=flat-square)](https://travis-ci.org/boyeborg/spritz)
-[![Codecov](https://img.shields.io/codecov/c/github/boyeborg/spritz/master.svg?style=flat-square)](https://codecov.io/gh/boyeborg/spritz)
-[![JitPack](https://img.shields.io/jitpack/v/boyeborg/spritz.svg?style=flat-square)](https://jitpack.io/#boyeborg/spritz)
+[![Build Status](https://img.shields.io/travis/boyeborg/spritz/master.svg?style=flat-square&longCache=true)](https://travis-ci.org/boyeborg/spritz)
+[![Codecov](https://img.shields.io/codecov/c/github/boyeborg/spritz/master.svg?style=flat-square&longCache=true)](https://codecov.io/gh/boyeborg/spritz)
+[![JitPack](https://img.shields.io/jitpack/v/boyeborg/spritz.svg?style=flat-square&longCache=true)](https://jitpack.io/#boyeborg/spritz)
 
 Freature extraction from event based streams.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Spritz
 
 [![Build Status](https://img.shields.io/travis/boyeborg/spritz/master.svg?style=flat-square)](https://travis-ci.org/boyeborg/spritz)
+[![Codecov](https://img.shields.io/codecov/c/github/boyeborg/spritz/master.svg?style=flat-square)](https://codecov.io/gh/boyeborg/spritz)
 
 Freature extraction from event based streams.


### PR DESCRIPTION
This adds badges from travis, codecov and jitpack to the top of the readme, and fixes #7.