### PR TITLE
enforce styling using checkstyle

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+		"http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+
+<!--
+	Checkstyle configuration that checks the Google coding conventions from Google
+	Java Style, that can be found at
+	https://google.github.io/styleguide/javaguide.html, configured to use tabs
+	instead of spaces.
+ -->
+
+<module name = "Checker">
+	<property name="charset" value="UTF-8"/>
+
+	<property name="severity" value="error"/>
+
+	<property name="fileExtensions" value="java, properties, xml"/>
+
+	<module name="TreeWalker">
+		<module name="OuterTypeFilename"/>
+		<module name="IllegalTokenText">
+			<property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+			<property name="format" value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+			<property name="message" value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+		</module>
+		<module name="AvoidEscapedUnicodeCharacters">
+			<property name="allowEscapesForControlCharacters" value="true"/>
+			<property name="allowByTailComment" value="true"/>
+			<property name="allowNonPrintableEscapes" value="true"/>
+		</module>
+		<module name="LineLength">
+			<property name="max" value="100"/>
+			<property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+		</module>
+		<module name="AvoidStarImport"/>
+		<module name="OneTopLevelClass"/>
+		<module name="NoLineWrap"/>
+		<module name="EmptyBlock">
+			<property name="option" value="TEXT"/>
+			<property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+		</module>
+		<module name="NeedBraces"/>
+		<module name="LeftCurly"/>
+		<module name="RightCurly">
+			<property name="id" value="RightCurlySame"/>
+			<property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+		</module>
+		<module name="RightCurly">
+			<property name="id" value="RightCurlyAlone"/>
+			<property name="option" value="alone"/>
+			<property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+		</module>
+		<module name="WhitespaceAround">
+			<property name="allowEmptyConstructors" value="true"/>
+			<property name="allowEmptyMethods" value="true"/>
+			<property name="allowEmptyTypes" value="true"/>
+			<property name="allowEmptyLoops" value="true"/>
+			<message key="ws.notFollowed"
+				value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+			<message key="ws.notPreceded"
+				value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+		</module>
+		<module name="OneStatementPerLine"/>
+		<module name="MultipleVariableDeclarations"/>
+		<module name="ArrayTypeStyle"/>
+		<module name="MissingSwitchDefault"/>
+		<module name="FallThrough"/>
+		<module name="UpperEll"/>
+		<module name="ModifierOrder"/>
+		<module name="EmptyLineSeparator">
+			<property name="allowNoEmptyLineBetweenFields" value="true"/>
+		</module>
+		<module name="SeparatorWrap">
+			<property name="id" value="SeparatorWrapDot"/>
+			<property name="tokens" value="DOT"/>
+			<property name="option" value="nl"/>
+		</module>
+		<module name="SeparatorWrap">
+			<property name="id" value="SeparatorWrapComma"/>
+			<property name="tokens" value="COMMA"/>
+			<property name="option" value="EOL"/>
+		</module>
+		<module name="SeparatorWrap">
+			<!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+			<property name="id" value="SeparatorWrapEllipsis"/>
+			<property name="tokens" value="ELLIPSIS"/>
+			<property name="option" value="EOL"/>
+		</module>
+		<module name="SeparatorWrap">
+			<!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+			<property name="id" value="SeparatorWrapArrayDeclarator"/>
+			<property name="tokens" value="ARRAY_DECLARATOR"/>
+			<property name="option" value="EOL"/>
+		</module>
+		<module name="SeparatorWrap">
+			<property name="id" value="SeparatorWrapMethodRef"/>
+			<property name="tokens" value="METHOD_REF"/>
+			<property name="option" value="nl"/>
+		</module>
+		<module name="PackageName">
+			<property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+			<message key="name.invalidPattern"
+				value="Package name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="TypeName">
+			<message key="name.invalidPattern"
+				value="Type name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="MemberName">
+			<property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+			<message key="name.invalidPattern"
+				value="Member name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="ParameterName">
+			<property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+			<message key="name.invalidPattern"
+				value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="CatchParameterName">
+			<property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+			<message key="name.invalidPattern"
+				value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="LocalVariableName">
+			<property name="tokens" value="VARIABLE_DEF"/>
+			<property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+			<message key="name.invalidPattern"
+				value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="ClassTypeParameterName">
+			<property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+			<message key="name.invalidPattern"
+				value="Class type name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="MethodTypeParameterName">
+			<property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+			<message key="name.invalidPattern"
+				value="Method type name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="InterfaceTypeParameterName">
+			<property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+			<message key="name.invalidPattern"
+				value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="NoFinalizer"/>
+		<module name="GenericWhitespace">
+			<message key="ws.followed"
+				value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+			<message key="ws.preceded"
+				value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+			<message key="ws.illegalFollow"
+				value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+			<message key="ws.notPreceded"
+				value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+		</module>
+		<module name="Indentation">
+			<!-- Tabs are interpereded as 8 spaces; tabs are superior -->
+			<property name="basicOffset" value="8"/>
+			<property name="braceAdjustment" value="0"/>
+			<property name="caseIndent" value="8"/>
+			<property name="throwsIndent" value="16"/>
+			<property name="lineWrappingIndentation" value="16"/>
+			<property name="arrayInitIndent" value="8"/>
+		</module>
+		<module name="AbbreviationAsWordInName">
+			<property name="ignoreFinal" value="false"/>
+			<property name="allowedAbbreviationLength" value="1"/>
+		</module>
+		<module name="OverloadMethodsDeclarationOrder"/>
+		<module name="VariableDeclarationUsageDistance"/>
+		<module name="CustomImportOrder">
+			<property name="sortImportsInGroupAlphabetically" value="true"/>
+			<property name="separateLineBetweenGroups" value="true"/>
+			<property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+		</module>
+		<module name="MethodParamPad"/>
+		<module name="NoWhitespaceBefore">
+			<property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
+			<property name="allowLineBreaks" value="true"/>
+		</module>
+		<module name="ParenPad"/>
+		<module name="OperatorWrap">
+			<property name="option" value="NL"/>
+			<property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+		</module>
+		<module name="AnnotationLocation">
+			<property name="id" value="AnnotationLocationMostCases"/>
+			<property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+		</module>
+		<module name="AnnotationLocation">
+			<property name="id" value="AnnotationLocationVariables"/>
+			<property name="tokens" value="VARIABLE_DEF"/>
+			<property name="allowSamelineMultipleAnnotations" value="true"/>
+		</module>
+		<module name="NonEmptyAtclauseDescription"/>
+		<module name="JavadocTagContinuationIndentation"/>
+		<module name="SummaryJavadoc">
+			<property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+		</module>
+		<module name="JavadocParagraph"/>
+		<module name="AtclauseOrder">
+			<property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+			<property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+		</module>
+		<module name="JavadocMethod">
+			<property name="scope" value="public"/>
+			<property name="allowMissingParamTags" value="true"/>
+			<property name="allowMissingThrowsTags" value="true"/>
+			<property name="allowMissingReturnTag" value="true"/>
+			<property name="minLineCount" value="2"/>
+			<property name="allowedAnnotations" value="Override, Test"/>
+			<property name="allowThrowsTagsForSubclasses" value="true"/>
+		</module>
+		<module name="MethodName">
+			<property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+			<message key="name.invalidPattern"
+				value="Method name ''{0}'' must match pattern ''{1}''."/>
+		</module>
+		<module name="SingleLineJavadoc">
+			<property name="ignoreInlineTags" value="false"/>
+		</module>
+		<module name="EmptyCatchBlock">
+			<property name="exceptionVariableName" value="expected"/>
+		</module>
+		<module name="CommentsIndentation"/>
+	</module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,32 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.0.0</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>8.9</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>validate</id>
+						<phase>validate</phase>
+						<configuration>
+							<configLocation>checkstyle.xml</configLocation>
+							<encoding>UTF-8</encoding>
+						</configuration>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	

--- a/src/main/java/com/github/boyeborg/spritz/Main.java
+++ b/src/main/java/com/github/boyeborg/spritz/Main.java
@@ -1,7 +1,7 @@
 package com.github.boyeborg.spritz;
 
 public class Main {
-	
+
 	public static void main(final String[] args) {
 		System.out.println("Hello, World!");
 	}


### PR DESCRIPTION
This adds styling checks to the build process using [maven-checkstyle-plugin](https://maven.apache.org/plugins/maven-checkstyle-plugin/). It uses a configured version of the google coding conventions from [Google Java Style](https://google.github.io/styleguide/javaguide.html) that uses tabs instead of spaces. This fixes #13.