### PR TITLE
improve tab support in checkstyle configuration

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -18,6 +18,7 @@
 	<property name="fileExtensions" value="java, properties, xml"/>
 
 	<module name="TreeWalker">
+		<property name="tabWidth" value="2"/>
 		<module name="OuterTypeFilename"/>
 		<module name="IllegalTokenText">
 			<property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
@@ -155,13 +156,13 @@
 				value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
 		</module>
 		<module name="Indentation">
-			<!-- Tabs are interpereded as 8 spaces; tabs are superior -->
-			<property name="basicOffset" value="8"/>
+			<!-- Tabs are interpreted as two spaces -->
+			<property name="basicOffset" value="2"/>
 			<property name="braceAdjustment" value="0"/>
-			<property name="caseIndent" value="8"/>
-			<property name="throwsIndent" value="16"/>
-			<property name="lineWrappingIndentation" value="16"/>
-			<property name="arrayInitIndent" value="8"/>
+			<property name="caseIndent" value="2"/>
+			<property name="throwsIndent" value="4"/>
+			<property name="lineWrappingIndentation" value="4"/>
+			<property name="arrayInitIndent" value="2"/>
 		</module>
 		<module name="AbbreviationAsWordInName">
 			<property name="ignoreFinal" value="false"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -164,6 +164,11 @@
 			<property name="lineWrappingIndentation" value="4"/>
 			<property name="arrayInitIndent" value="2"/>
 		</module>
+		<!-- Enforce tabs -->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\t*(?! \*) "/>
+			<property name="message" value="Indent must use tab characters"/>
+		</module>
 		<module name="AbbreviationAsWordInName">
 			<property name="ignoreFinal" value="false"/>
 			<property name="allowedAbbreviationLength" value="1"/>


### PR DESCRIPTION
Changed the tab width to two spaces. This way the max line width is more accurate. Also added a regex to enforce the use of tabs when indenting.